### PR TITLE
Fixed profile to work with DATASIM

### DIFF
--- a/Objects/Level_1/ELRRProfile.json
+++ b/Objects/Level_1/ELRRProfile.json
@@ -229,10 +229,6 @@
                     ]
                 },
                 {
-                    "location": "$.context.contextActivities",
-                    "presence": "excluded"
-                },
-                {
                     "location": "$.object.id",
                     "presence": "included",
                     "scopeNote": {


### PR DESCRIPTION
Allowed context activities in the launched statement template.

This is what was causing DATASIM to send empty arrays. I am unsure why this is, but am reaching out to their team to resolve this.